### PR TITLE
Updated the dependencies from upstream setup.py

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.0.0" %}
+{% set version = "5.0.3" %}
 
 package:
   name: spyder
@@ -6,12 +6,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/s/spyder/spyder-{{ version }}.tar.gz
-  sha256: 0028f1fc347bf9085df9d45a82db515e91d676a259de1f3144c50bccd12c5f9a
+  sha256: 3422de6446286abe80a362d72cd8f1a96bf8cd323f485b0fc30fd51704062ed2
   patches:
     # See spyder-ide/spyder#8316
     - osx-zmq.patch
     # Remove once 5.0.1 is released
-    - fix-kernel-dep-warning.patch
+    #- fix-kernel-dep-warning.patch
 
 build:
   number: 1
@@ -25,6 +25,8 @@ requirements:
     - python
     - pip
     - setuptools
+    - wheel
+    - patch        # [not win]
   run:
     - python
     - applaunchservices >=0.1.7  # [osx]
@@ -48,7 +50,7 @@ requirements:
     - pygments >=2.0
     - pylint >=1.0
     - pyls-black >=0.4.6
-    - pyls-spyder >=0.3.2
+    - pyls-spyder >=0.3.2,<0.4.0
     - pyqt >=5.6,<5.13
     - python.app  # [osx]
     - python-language-server >=0.36.2,<1.0.0
@@ -56,13 +58,13 @@ requirements:
     - pyzmq >=17
     - qdarkstyle 3.0.2
     - qstylizer >=0.1.10
-    - qtawesome >=0.5.7
-    - qtconsole >=5.0.3
+    - qtawesome >=1.0.2
+    - qtconsole >=5.1.0
     - qtpy >=1.5.0
-    - rtree >=0.8.3
+    - rtree >=0.9.7
     - setuptools >=39.0.0
     - sphinx >=0.6.6
-    - spyder-kernels >=2.0.1,<2.1.0
+    - spyder-kernels >=2.0.3,<2.1.0
     - textdistance >=4.2.0
     - three-merge >=0.1.1
     - watchdog >=0.10.3,<2.0.0


### PR DESCRIPTION
Updated the dependencies from upstream setup.py to meta.yaml

Category: anaconda
Version change: bump from 5.0.0 to 5.0.3
Changelog: https://github.com/spyder-ide/spyder/blob/master/CHANGELOG.md
Upstream Issues: https://github.com/spyder-ide/spyder/issues - Lot of issues
Requirements https://github.com/spyder-ide/spyder/blob/master/setup.py
License : https://github.com/spyder-ide/spyder/blob/master/LICENSE.txt
The package builds correctly on concourse.
