### PR TITLE
Fix building for py36-38

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,14 +22,14 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - setuptools
     - wheel
     - patch     # [not win]
     - m2-patch  # [win]
   run:
-    - python >=3.6
+    - python
     - applaunchservices >=0.1.7  # [osx]
     - atomicwrites >=1.2.0
     - chardet >=2.0.0


### PR DESCRIPTION
Changed the python >=3.6 host and run requirements to just plain python, without the version restrictions.
So missing artifacts for py36-py38 will be built.