### PR TITLE
Restore windows menu

### DIFF
--- a/recipe/menu-windows.json
+++ b/recipe/menu-windows.json
@@ -1,5 +1,5 @@
 {
-    "menu_name": "${DISTRIBUTION_NAME}",
+    "menu_name": "Anaconda${PY_VER} ${PLATFORM}",
     "menu_items":
     [
         {

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,8 +74,6 @@ requirements:
     - textdistance >=4.2.0
     - three-merge >=0.1.1
     - watchdog >=0.10.3
-  run_constrained:
-    - menuinst >=1.4.17
 
 test:
   # NOTE: Since this is a GUI application, built packages should be uploaded to

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - py36-rtree-0.9.4.patch  # [win and py==36]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [ppc64le or s390x]
   skip: true  # [py36 and aarch64]
   entry_points:


### PR DESCRIPTION
For Anaconda's release of Spyder, restore the original menu name until all the other shortcuts align.