### PR TITLE
update 5.4.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,2 @@
-amays23-staging: spyder-staging
+channels:
+  amays23-staging: spyder-staging

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+amays23-staging: spyder-staging

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [ppc64le or s390x or py<37]
+  skip: true  # [ppc64le or s390x or py<38]
   entry_points:
     - spyder = spyder.app.start:main
   osx_is_app: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,7 +72,7 @@ requirements:
     # See: https://github.com/conda-forge/flake8-feedstock/issues/52
    - importlib-metadata <4.3 # [py<38]
   run_constrained:
-    - menuinst >=1.4.17
+    - menuinst >=1.4.17 
 
 test:
   # NOTE: Since this is a GUI application, built packages should be uploaded to

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,7 +69,6 @@ requirements:
    - watchdog >=0.10.3
     # This is here to workaround an inconsistency with flake8
     # See: https://github.com/conda-forge/flake8-feedstock/issues/52
-    - importlib-metadata >=4.3  # [py<38]
   run_constrained:
     - menuinst >=1.4.17
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,12 +63,13 @@ requirements:
    - rtree >=0.9.7
    - setuptools >=49.6.0
    - sphinx >=0.6.6
-   - spyder-kernels >=2.4.2,<2.5.0
+   - spyder-kernels >=2.4.1,<2.5.0
    - textdistance >=4.2.0
    - three-merge >=0.1.1
    - watchdog >=0.10.3
     # This is here to workaround an inconsistency with flake8
     # See: https://github.com/conda-forge/flake8-feedstock/issues/52
+   - importlib-metadata <4.3 # [py < 38]
   run_constrained:
     - menuinst >=1.4.17
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,7 +69,7 @@ requirements:
    - watchdog >=0.10.3
     # This is here to workaround an inconsistency with flake8
     # See: https://github.com/conda-forge/flake8-feedstock/issues/52
-    - importlib-metadata <4.3  # [py<38]
+    - importlib-metadata >=4.3  # [py<38]
   run_constrained:
     - menuinst >=1.4.17
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 build:
   number: 0
   skip: true  # [ppc64le or s390x or py<38]
+  # spyder-kernels is not available for python versions less than 3.8
   entry_points:
     - spyder = spyder.app.start:main
   osx_is_app: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
    - cookiecutter >=1.6.0
    - diff-match-patch >=20181111
    - intervaltree >=3.0.2
-   - ipython >=7.31.1,<8.0.0
+   - ipython >=7.31.1,<9.0.0
    - jedi >=0.17.2,<0.19.0
    - jellyfish >=0.7
    - jsonschema >=3.2.0
@@ -63,7 +63,7 @@ requirements:
    - rtree >=0.9.7
    - setuptools >=49.6.0
    - sphinx >=0.6.6
-   - spyder-kernels >=2.4.1,<2.5.0
+   - spyder-kernels >=2.4.2,<2.5.0
    - textdistance >=4.2.0
    - three-merge >=0.1.1
    - watchdog >=0.10.3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,7 +70,7 @@ requirements:
    - watchdog >=0.10.3
     # This is here to workaround an inconsistency with flake8
     # See: https://github.com/conda-forge/flake8-feedstock/issues/52
-   - importlib-metadata <4.3 # [py < 38]
+   - importlib-metadata <4.3 # [py<38]
   run_constrained:
     - menuinst >=1.4.17
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
    - cookiecutter >=1.6.0
    - diff-match-patch >=20181111
    - intervaltree >=3.0.2
-   - ipython >=7.31.1,<9.0.0
+   - ipython >=7.31.1,<8.0.0
    - jedi >=0.17.2,<0.19.0
    - jellyfish >=0.7
    - jsonschema >=3.2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.3.3" %}
+{% set version = "5.4.1" %}
 
 package:
   name: spyder
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/s/spyder/spyder-{{ version }}.tar.gz
-  sha256: bd68709f4ef38075fbffbb80cf47a43709c088a2c408207306ae3b4ed4da1df1
+  sha256: 91004e6115e18f3f8e424ed59716ff50a8838bdda603c89a96c150f90cea8651
 
 build:
   number: 0
@@ -22,52 +22,51 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python
-    - applaunchservices >=0.3.0  # [osx]
-    - atomicwrites >=1.2.0
-    - chardet >=2.0.0
-    - cloudpickle >=0.5.0
-    - cookiecutter >=1.6.0
-    - diff-match-patch >=20181111
-    - intervaltree >=3.0.2
-    - ipython >=7.31.1,<8.0.0
-    - jedi >=0.17.2,<0.19.0
-    - jellyfish >=0.7
-    - jsonschema >=3.2.0
-    - keyring >=17.0.0
-    - nbconvert >=4.0
-    - numpydoc >=0.6.0
-    # Required to get SSH connections to remote kernels
-    - paramiko >=2.4.0  # [win]
-    - parso >=0.7.0,<0.9.0
-    - pexpect >=4.4.0
-    - pickleshare >=0.4
-    - ptyprocess >=0.5  # [win]
-    - psutil >=5.3
-    - pygments >=2.0
-    - pylint >=2.5.0,<3.0
-    - python-lsp-black >=1.2.0
-    - pyls-spyder >=0.4.0
-    # Make Spyder work with PyQt 5.15, see https://github.com/spyder-ide/spyder/commit/a68e8b933b551581ed8d7504fe9430de66782927
-    - pyqt >=5.6,<5.16
-    # pyqtwebengine versions are available starting from 5.15+ 
-    - pyqtwebengine >=5.15,<5.16
-    - python.app  # [osx]
-    - python-lsp-server >=1.5.0,<1.6.0
-    - pyxdg >=0.26  # [linux]
-    - pyzmq >=22.1.0
-    - qdarkstyle >=3.0.2,<3.1.0
-    - qstylizer >=0.1.10
-    - qtawesome >=1.0.2
-    - qtconsole >=5.3.2,<5.4.0
-    - qtpy >=2.1.0
-    - rtree >=0.9.7
-    - setuptools >=49.6.0
-    - sphinx >=0.6.6
-    - spyder-kernels >=2.3.3,<2.4.0
-    - textdistance >=4.2.0
-    - three-merge >=0.1.1
-    - watchdog >=0.10.3
+   - python
+   - applaunchservices >=0.3.0  # [osx]
+   - atomicwrites >=1.2.0
+   - chardet >=2.0.0
+   - cloudpickle >=0.5.0
+   - cookiecutter >=1.6.0
+   - diff-match-patch >=20181111
+   - intervaltree >=3.0.2
+   - ipython >=7.31.1,<9.0.0
+   - jedi >=0.17.2,<0.19.0
+   - jellyfish >=0.7
+   - jsonschema >=3.2.0
+   - keyring >=17.0.0
+   - nbconvert >=4.0
+   - numpydoc >=0.6.0
+   - paramiko >=2.4.0  # [win]
+   - parso >=0.7.0,<0.9.0
+   - pexpect >=4.4.0
+   - pickleshare >=0.4
+   # This is here to work around a bug in mamba
+   - ptyprocess >=0.5  # [win]
+   - psutil >=5.3
+   - pygments >=2.0
+   - pylint >=2.5.0,<3.0
+   - pylint-venv >=2.1.1
+   - python-lsp-black >=1.2.0
+   - pyls-spyder >=0.4.0
+   - pyqt >=5.6,<5.16
+   - pyqtwebengine <5.16
+   - python.app  # [osx]
+   - python-lsp-server >=1.7.0,<1.8.0
+   - pyxdg >=0.26  # [linux]
+   - pyzmq >=22.1.0
+   - qdarkstyle >=3.0.2,<3.1.0
+   - qstylizer >=0.2.2
+   - qtawesome >=1.2.1
+   - qtconsole >=5.4.0,<5.5.0
+   - qtpy >=2.1.0
+   - rtree >=0.9.7
+   - setuptools >=49.6.0
+   - sphinx >=0.6.6
+   - spyder-kernels >=2.4.1,<2.5.0
+   - textdistance >=4.2.0
+   - three-merge >=0.1.1
+   - watchdog >=0.10.3
     # This is here to workaround an inconsistency with flake8
     # See: https://github.com/conda-forge/flake8-feedstock/issues/52
     - importlib-metadata <4.3  # [py<38]


### PR DESCRIPTION
## Spyder 5.4.1 Update
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-973)
[Upstream](https://github.com/spyder-ide/spyder)
[Dependencies ](https://github.com/spyder-ide/spyder/blob/master/requirements/main.yml)
# Changes
- Updated version number and `sha256`
- Added `skip: True` for `python` versions less than `3.8 `
- Updated pinnings on dependencies to match necessary upstream requirements
