### PR TITLE
Menuinst2 shortcuts: handle paths with spaces

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: fb3f098f4780fe6607d6bf19414c98505324ee1d660718e84c3e58664d1c1f49
 
 build:
-  number: 1
+  number: 2
   skip: true  # [s390x or py<38]
   entry_points:
     - spyder = spyder.app.start:main

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -10,8 +10,10 @@ REM prefixes with spaces in the name cannot be properly escaped.
 REM Use a temporary file as a workaround.
 SET TMPLOG="%PREFIX%\.%PKG_NAME%-post-link.tmp.log"
 "%CONDA_PYTHON_EXE%" -c "import menuinst; print(tuple(int(x) for x in menuinst.__version__.split(\".\"))[:3] < (2, 1, 0))" > %TMPLOG%
+IF ERRORLEVEL 1 EXIT 1
 SET /P OLD_MENUINST=<%TMPLOG%
-DEL %TMPLOG% IF "%OLD_MENUINST%" == "True" GOTO :use_menuinst_v1
+DEL %TMPLOG%
+IF "%OLD_MENUINST%" == "True" GOTO :use_menuinst_v1
 
 COPY /y "%PREFIX%\Menu\%PKG_NAME%_menu-v2.json.bak" "%PREFIX%\Menu\%PKG_NAME%_menu.json"
 GOTO :exit

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,7 +1,7 @@
 @ECHO OFF
 
 REM The menuinst v2 json file is not compatible with menuinst versions
-REM REM older than 2.1.0. Copy the appropriate file as the menu file.
+REM older than 2.1.0. Copy the appropriate file as the menu file.
 
 SET LOGFILE="%PREFIX%\.messages.txt"
 
@@ -18,7 +18,7 @@ GOTO :exit
     ECHO Warning: using menuinst v1 shortcuts. >> %LOGFILE%
     ECHO menuinst v1 is marked as legacy and is no longer maintained. >> %LOGFILE%
     ECHO Please update menuinst in the base environment and reinstall %PKG_NAME%. >> %LOGFILE%
-GOTO :exit
+    GOTO :exit
 
 :exit
     EXIT /B %ERRORLEVEL%

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -8,7 +8,7 @@ SET LOGFILE="%PREFIX%\.messages.txt"
 REM Cannot use usual FOR-loop way to assign output of command because
 REM prefixes with spaces in the name cannot be properly escaped.
 REM Use a temporary file as a workaround.
-SET TMPLOG="%PREFIX%\.post-link.tmp.log"
+SET TMPLOG="%PREFIX%\.%PKG_NAME%-post-link.tmp.log"
 "%CONDA_PYTHON_EXE%" -c "import menuinst; print(tuple(int(x) for x in menuinst.__version__.split(\".\"))[:3] < (2, 1, 0))" > %TMPLOG%
 SET /P OLD_MENUINST=<%TMPLOG%
 DEL %TMPLOG% IF "%OLD_MENUINST%" == "True" GOTO :use_menuinst_v1

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -3,22 +3,22 @@
 REM The menuinst v2 json file is not compatible with menuinst versions
 REM older than 2.1.0. Copy the appropriate file as the menu file.
 
-SET LOGFILE=%PREFIX%\.messages.txt
+SET LOGFILE="%PREFIX%\.messages.txt"
 
 FOR /F %%i IN (
-    '%CONDA_PYTHON_EXE% -c "import menuinst; print(tuple(int(x) for x in menuinst.__version__.split(\".\"))[:3] < (2, 1, 0))"'
+    '"%CONDA_PYTHON_EXE%" -c "import menuinst; print(tuple(int(x) for x in menuinst.__version__.split(\".\"))[:3] < (2, 1, 0))"'
 ) DO (
     IF "%%~i"=="True" GOTO :use_menuinst_v1
 )
-COPY /y %PREFIX%\Menu\%PKG_NAME%_menu-v2.json.bak %PREFIX%\Menu\%PKG_NAME%_menu.json
+COPY /y "%PREFIX%\Menu\%PKG_NAME%_menu-v2.json.bak" "%PREFIX%\Menu\%PKG_NAME%_menu.json"
 GOTO :exit
 
 :use_menuinst_v1:
-    COPY /y %PREFIX%\Menu\%PKG_NAME%_menu-v1.json.bak %PREFIX%\Menu\%PKG_NAME%_menu.json
+    COPY /y "%PREFIX%\Menu\%PKG_NAME%_menu-v1.json.bak" "%PREFIX%\Menu\%PKG_NAME%_menu.json"
     ECHO. >> %LOGFILE%
-    ECHO Warning: using menuinst v1 shortcuts. >> %LOGFILE%
-    ECHO menuinst v1 is marked as legacy and is no longer maintained. >> %LOGFILE%
-    ECHO Please update menuinst in the base environment and reinstall %PKG_NAME%. >> %LOGFILE%
+    ECHO Warning: using menuinst v1 shortcuts. >> "%LOGFILE%"
+    ECHO menuinst v1 is marked as legacy and is no longer maintained. >> "%LOGFILE%"
+    ECHO Please update menuinst in the base environment and reinstall %PKG_NAME%. >> "%LOGFILE%"
     GOTO :exit
 
 :exit

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -3,22 +3,22 @@
 REM The menuinst v2 json file is not compatible with menuinst versions
 REM older than 2.1.0. Copy the appropriate file as the menu file.
 
-SET LOGFILE="%PREFIX%\.messages.txt"
+SET LOGFILE=%PREFIX%\.messages.txt
 
 FOR /F "delims=" %%i IN (
-    '"%CONDA_PYTHON_EXE%" -c "import menuinst; print(tuple(int(x) for x in menuinst.__version__.split(\".\"))[:3] < (2, 1, 0))"'
+    '%CONDA_PYTHON_EXE% -c "import menuinst; print(tuple(int(x) for x in menuinst.__version__.split(\".\"))[:3] < (2, 1, 0))"'
 ) DO (
     IF "%%~i"=="True" GOTO :use_menuinst_v1
 )
-COPY /y "%PREFIX%\Menu\%PKG_NAME%_menu-v2.json.bak" "%PREFIX%\Menu\%PKG_NAME%_menu.json"
+COPY /y %PREFIX%\Menu\%PKG_NAME%_menu-v2.json.bak %PREFIX%\Menu\%PKG_NAME%_menu.json
 GOTO :exit
 
 :use_menuinst_v1:
-    COPY /y "%PREFIX%\Menu\%PKG_NAME%_menu-v1.json.bak" "%PREFIX%\Menu\%PKG_NAME%_menu.json"
+    COPY /y %PREFIX%\Menu\%PKG_NAME%_menu-v1.json.bak %PREFIX%\Menu\%PKG_NAME%_menu.json
     ECHO. >> %LOGFILE%
-    ECHO Warning: using menuinst v1 shortcuts. >> "%LOGFILE%"
-    ECHO menuinst v1 is marked as legacy and is no longer maintained. >> "%LOGFILE%"
-    ECHO Please update menuinst in the base environment and reinstall %PKG_NAME%. >> "%LOGFILE%"
+    ECHO Warning: using menuinst v1 shortcuts. >> %LOGFILE%
+    ECHO menuinst v1 is marked as legacy and is no longer maintained. >> %LOGFILE%
+    ECHO Please update menuinst in the base environment and reinstall %PKG_NAME%. >> %LOGFILE%
     GOTO :exit
 
 :exit

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -5,7 +5,7 @@ REM older than 2.1.0. Copy the appropriate file as the menu file.
 
 SET LOGFILE="%PREFIX%\.messages.txt"
 
-FOR /F "/delims=" %%i IN (
+FOR /F "delims=" %%i IN (
     '"%CONDA_PYTHON_EXE%" -c "import menuinst; print(tuple(int(x) for x in menuinst.__version__.split(\".\"))[:3] < (2, 1, 0))"'
 ) DO (
     IF "%%~i"=="True" GOTO :use_menuinst_v1

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -7,14 +7,8 @@ SET LOGFILE="%PREFIX%\.messages.txt"
 
 REM Cannot use usual FOR-loop way to assign output of command because
 REM prefixes with spaces in the name cannot be properly escaped.
-REM Use a temporary file as a workaround.
-SET TMPLOG="%PREFIX%\.%PKG_NAME%-post-link.tmp.log"
-"%CONDA_PYTHON_EXE%" -c "import menuinst; print(tuple(int(x) for x in menuinst.__version__.split(\".\"))[:3] < (2, 1, 0))" > %TMPLOG%
-IF ERRORLEVEL 1 EXIT 1
-SET /P OLD_MENUINST=<%TMPLOG%
-DEL %TMPLOG%
-IF "%OLD_MENUINST%" == "True" GOTO :use_menuinst_v1
-
+"%CONDA_PYTHON_EXE%" -c "import menuinst, sys; sys.exit(1 if tuple(int(x) for x in menuinst.__version__.split(\".\"))[:3] < (2, 1, 0) else 0)"
+IF %ERRORLEVEL% == 1 GOTO :use_menuinst_v1
 COPY /y "%PREFIX%\Menu\%PKG_NAME%_menu-v2.json.bak" "%PREFIX%\Menu\%PKG_NAME%_menu.json"
 GOTO :exit
 
@@ -27,4 +21,4 @@ GOTO :exit
 GOTO :exit
 
 :exit
-    EXIT /B %ERRORLEVEL%
+    EXIT /B %ERRORLEVEL%

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,25 +1,28 @@
 @ECHO OFF
 
 REM The menuinst v2 json file is not compatible with menuinst versions
-REM older than 2.1.0. Copy the appropriate file as the menu file.
+REM REM older than 2.1.0. Copy the appropriate file as the menu file.
 
-SET LOGFILE=%PREFIX%\.messages.txt
+SET LOGFILE="%PREFIX%\.messages.txt"
 
-FOR /F "delims=" %%i IN (
-    '%CONDA_PYTHON_EXE% -c "import menuinst; print(tuple(int(x) for x in menuinst.__version__.split(\".\"))[:3] < (2, 1, 0))"'
-) DO (
-    IF "%%~i"=="True" GOTO :use_menuinst_v1
-)
-COPY /y %PREFIX%\Menu\%PKG_NAME%_menu-v2.json.bak %PREFIX%\Menu\%PKG_NAME%_menu.json
+REM Cannot use usual FOR-loop way to assign output of command because
+REM prefixes with spaces in the name cannot be properly escaped.
+REM Use a temporary file as a workaround.
+SET TMPLOG="%PREFIX%\.post-link.tmp.log"
+"%CONDA_PYTHON_EXE%" -c "import menuinst; print(tuple(int(x) for x in menuinst.__version__.split(\".\"))[:3] < (2, 1, 0))" > %TMPLOG%
+SET /P OLD_MENUINST=<%TMPLOG%
+DEL %TMPLOG% IF "%OLD_MENUINST%" == "True" GOTO :use_menuinst_v1
+
+COPY /y "%PREFIX%\Menu\%PKG_NAME%_menu-v2.json.bak" "%PREFIX%\Menu\%PKG_NAME%_menu.json"
 GOTO :exit
 
 :use_menuinst_v1:
-    COPY /y %PREFIX%\Menu\%PKG_NAME%_menu-v1.json.bak %PREFIX%\Menu\%PKG_NAME%_menu.json
+    COPY /y "%PREFIX%\Menu\%PKG_NAME%_menu-v1.json.bak" "%PREFIX%\Menu\%PKG_NAME%_menu.json"
     ECHO. >> %LOGFILE%
     ECHO Warning: using menuinst v1 shortcuts. >> %LOGFILE%
     ECHO menuinst v1 is marked as legacy and is no longer maintained. >> %LOGFILE%
     ECHO Please update menuinst in the base environment and reinstall %PKG_NAME%. >> %LOGFILE%
-    GOTO :exit
+GOTO :exit
 
 :exit
-    EXIT /B %ERRORLEVEL%
+    EXIT /B %ERRORLEVEL%

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -5,7 +5,7 @@ REM older than 2.1.0. Copy the appropriate file as the menu file.
 
 SET LOGFILE="%PREFIX%\.messages.txt"
 
-FOR /F %%i IN (
+FOR /F "/delims=" %%i IN (
     '"%CONDA_PYTHON_EXE%" -c "import menuinst; print(tuple(int(x) for x in menuinst.__version__.split(\".\"))[:3] < (2, 1, 0))"'
 ) DO (
     IF "%%~i"=="True" GOTO :use_menuinst_v1


### PR DESCRIPTION
spyder 5.5.1

**Destination channel**: defaults

### Links

- [Upstream repository](https://github.com/spyder-ide/spyder)

### Explanation of changes:

- Add quotes around paths for installation paths with spaces on Windows.
- Use exit code since the for-loop structure does not work for paths with spaces.
