### PR TITLE
Updated to 6.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.5.1" %}
+{% set version = "6.0.1" %}
 {% set name = "spyder" %}
 
 package:
@@ -7,10 +7,13 @@ package:
 
 source:
   url: https://pypi.io/packages/source/s/spyder/spyder-{{ version }}.tar.gz
-  sha256: fb3f098f4780fe6607d6bf19414c98505324ee1d660718e84c3e58664d1c1f49
+  sha256: 709782e88091588bbe614de6ebbde7b47544a4d6c225e199de5ad22b77d8b130
+  patches:
+    # See spyder-ide/spyder#8316
+    - osx-zmq.patch
 
 build:
-  number: 4
+  number: 0
   skip: true  # [s390x or py<38]
   entry_points:
     - spyder = spyder.app.start:main
@@ -24,57 +27,75 @@ requirements:
     - pip
     - setuptools
     - wheel
+    - packaging
   run:
    - python
-   - applaunchservices >=0.3.0  # [osx]
+   - python.app                        # [osx]
+   # This is here to work around a bug in mamba
+   - ptyprocess >=0.5                  # [win]
+   - aiohttp >=3.9.3
+   - applaunchservices >=0.3.0         # [osx]
+   - asyncssh >=2.14.0,<3.0.0
    - atomicwrites >=1.2.0
    - chardet >=2.0.0
    - cloudpickle >=0.5.0
    - cookiecutter >=1.6.0
    - diff-match-patch >=20181111
+   - importlib-metadata >=4.6.0        # [py<310]
    - intervaltree >=3.0.2
-   - ipython >=8.12.2,<8.13.0  # [py==38]
+   - ipython >=8.12.2,<8.13.0          # [py==38]
    - ipython >=8.13.0,<9.0.0,!=8.17.1  # [py>38]
    - jedi >=0.17.2,<0.20.0
-   - jellyfish >=0.7          # [not (osx and arm64 and py<312)]
+   - jellyfish >=0.7                   # [not (osx and arm64 and py<312)]
    # Tests fail with "jellyfish 1.0.1 is not supported on this platform"
-   - jellyfish >=0.7,!=1.0.1  # [osx and arm64 and py<312]
+   - jellyfish >=0.7,!=1.0.1           # [osx and arm64 and py<312]
    - jsonschema >=3.2.0
    - keyring >=17.0.0
    - nbconvert >=4.0
    - numpydoc >=0.6.0
-   - paramiko >=2.4.0  # [win]
    - parso >=0.7.0,<0.9.0
    - pexpect >=4.4.0
    - pickleshare >=0.4
-   # This is here to work around a bug in mamba
-   - ptyprocess >=0.5  # [win]
    - psutil >=5.3
+   - pygithub >=2.3.0
    - pygments >=2.0
-   - pylint >=2.5.0,<3.1
+   - pylint >=3.1,<4
    - pylint-venv >=3.0.2
-   - python-lsp-black >=2.0.0,<3.0.0
    - pyls-spyder >=0.4.0
-   - pyqt >=5.10,<5.16
-   - pyqtwebengine >=5.10,<5.16
-   - python.app  # [osx]
-   - python-lsp-server >=1.10.0,<1.11.0
-   - pyxdg >=0.26  # [linux]
-   - pyzmq >=22.1.0
+   - pyqt >=5.15,<5.16
+   - pyqtwebengine >=5.15,<5.16
+   - python-lsp-black >=2.0.0,<3.0.0
+   - python-lsp-server >=1.12.0,<1.13.0
+   - pyuca >=1.2
+   - pyxdg >=0.26                      # [linux]
+   - pyzmq >=24.0.0
    - qdarkstyle >=3.2.0,<3.3.0
    - qstylizer >=0.2.2
-   - qtawesome >=1.2.1
-   - qtconsole >=5.5.1,<5.6.0
-   - qtpy >=2.1.0
+   - qtawesome >=1.3.1,<1.4.0
+   - qtconsole >=5.6.0,<5.7.0
+   - qtpy >=2.4.0
    - rtree >=0.9.7
    - setuptools >=49.6.0
    - sphinx >=0.6.6
-   - spyder-kernels >=2.5.0,<2.6.0
+   - spyder-kernels >=3.0.0,<3.1.0
+   - superqt >=0.6.2,<1.0.0
    - textdistance >=4.2.0
    - three-merge >=0.1.1
    - watchdog >=0.10.3
+   - yarl >=1.9.4
   run_constrained:
-    - menuinst >=1.4.17 
+    - menuinst >=2.1.2
+    # Optional dependencies from python-lsp-server[all] that the Spyder devs have opted to include by default.
+    - autopep8 >=2.0.4,<2.1.0
+    - flake8 >=7.1,<8
+    - mccabe >=0.7.0,<0.8.0
+    - pycodestyle >=2.12.0,<2.13.0
+    - pydocstyle >=6.3.0,<6.4.0
+    - pyflakes >=3.2.0,<3.3.0
+    - pylint >=3.1,<4
+    - rope >=1.11.0
+    - yapf >=0.33.0
+    - whatthepatch >=1.0.2,<2.0.0
 
 test:
   # NOTE: Since this is a GUI application, built packages should be uploaded to
@@ -91,6 +112,20 @@ test:
 {% if target_platform != "linux-aarch64" and target_platform != "linux-64"%}
   imports:
     - spyder
+    - spyder.api
+    - spyder.api.config
+    - spyder.api.plugin_registration
+    - spyder.api.plugins
+    - spyder.api.shellconnect
+    - spyder.api.widgets
+    - spyder.app
+    - spyder.config
+    - spyder.plugins
+    - spyder.utils
+    - spyder.utils.external
+    - spyder.utils.introspection
+    - spyder.utils.snippets
+    - spyder.widgets
 {% endif %}
 
 app:

--- a/recipe/osx-zmq.patch
+++ b/recipe/osx-zmq.patch
@@ -1,0 +1,14 @@
+diff --git a/spyder/app/start.py b/spyder/app/start.py
+index bbeac112a..4883c6c47 100644
+--- a/spyder/app/start.py
++++ b/spyder/app/start.py
+@@ -18,7 +18,8 @@ import time
+
+ # To prevent a race condition with ZMQ
+ # See spyder-ide/spyder#5324.
+-import zmq
++if not sys.platform == 'darwin':
++    import zmq
+
+ # Load GL library to prevent segmentation faults on some Linux systems
+ # See spyder-ide/spyder#3226 and spyder-ide/spyder#3332.


### PR DESCRIPTION
spyder 6.0.1

**Destination channel:** defaults

### Links

- [PKG-5640](https://anaconda.atlassian.net/browse/PKG-5640)
- [Upstream repository](https://github.com/spyder-ide/spyder/blob/v6.0.1)
- [Upstream changelog/diff](https://github.com/spyder-ide/spyder/blob/v6.0.1/CHANGELOG.md)
- Relevant dependency PRs:
  - AnacondaRecipes/asyncssh-feedstock#2

### Explanation of changes:

- Updated deps for new version
- Added more import tests


[PKG-5640]: https://anaconda.atlassian.net/browse/PKG-5640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ