### PR TITLE
Revert changes to make Spyder 6.0.8 work with PyQt6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,12 +9,12 @@ source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: be62114d10c4339b1c0b22e702ea90597fbb19f269a8d6c700b4693a9eb12b63
   patches:
-    - patches/0001-patch-for-pyqt6-usage.patch
+    # - patches/0001-patch-for-pyqt6-usage.patch
     # See spyder-ide/spyder#8316
     - patches/0002-osx-zmq.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<38]
   entry_points:
     - spyder = spyder.app.start:main
@@ -84,8 +84,8 @@ requirements:
    - watchdog >=0.10.3
    - yarl >=1.9.4
    # qt_requirements
-   - pyqt >=6.5,<7
-   - pyqtwebengine >=6.5,<7
+   - pyqt >=5.15,<5.16
+   - pyqtwebengine >=5.15,<5.16
    - qtconsole >=5.6.1,<5.7.0
    # python-lsp-server[all]
    # bounds set in package python-lsp-server


### PR DESCRIPTION
{package} {version} {:snowflake:}

**Destination channel:** {Snowflake | defaults}

### Links

- [{ticket_number}]() 
- [Upstream repository]()
- [Upstream changelog/diff]()
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- I'm the Spyder maintainer and with this PR I'm kindly requesting the Anaconda team that the changes done in commit 2558ad0 be reverted.
- Spyder 6.0.x is not ready to work with PyQt6. At the time we released 6.0.0 last year, we could only check that that version starts with PyQt6, but not properly test it.
- Due do that, we're now flooded by [bug](https://github.com/spyder-ide/spyder/issues?q=is%3Aissue%20state%3Aclosed%20created%3A%3E%40today-1w%20SpyderButtonsProxyStyle) [reports](https://github.com/spyder-ide/spyder/issues/25084) from Anaconda users due to this change.
- However, for the upcoming 6.1.0 version (to be released this week) we fixed many bugs and added CI testing for PyQt6. So that version will be in much better shape if you want to use it with PyQt6 instead of version 5.
- Finally, we'd appreciate if you also mark 6.0.8 build 0 as broken in your `repodata.json` so it's not picked up by the conda solver when people want to use Spyder with PyQt6.