### PR TITLE
update menu-v2 on menu-v3

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -14,9 +14,9 @@ IF NOT EXIST "%MENU_DIR%" MKDIR "%MENU_DIR%"
 if errorlevel 1 exit 1
 copy "%RECIPE_DIR%\menu-v1.json" "%MENU_DIR%\%PKG_NAME%_menu-v1.json.bak"
 if errorlevel 1 exit 1
-copy "%RECIPE_DIR%\menu-v2.json" "%MENU_DIR%\%PKG_NAME%_menu-v2.json.bak"
+copy "%RECIPE_DIR%\menu-v3.json" "%MENU_DIR%\%PKG_NAME%_menu-v3.json.bak"
 if errorlevel 1 exit 1
-copy "%RECIPE_DIR%\menu-v2.json" "%MENU_DIR%\%PKG_NAME%_menu.json"
+copy "%RECIPE_DIR%\menu-v3.json" "%MENU_DIR%\%PKG_NAME%_menu.json"
 if errorlevel 1 exit 1
 copy "%SRC_DIR%\img_src\spyder.ico" "%MENU_DIR%\spyder.ico"
 if errorlevel 1 exit 1

--- a/recipe/menu-v3.json
+++ b/recipe/menu-v3.json
@@ -1,6 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft-07/schema",
-    "$id": "https://schemas.conda.io/menuinst-1.schema.json",
+    "$schema": "https://schemas.conda.org/menuinst/menuinst-1-1-3.schema.json",
     "menu_name": "Anaconda ({{ DISTRIBUTION_NAME }})",
     "menu_items": [
         {
@@ -16,11 +15,8 @@
                     "quicklaunch": false,
                     "command": ["{{ PYTHONW }}", "{{ SCRIPTS_DIR }}/spyder-script.py"],
                     "app_user_model_id": "anaconda.Spyder.{{ DISTRIBUTION_NAME }}.{{ ENV_NAME }}"
-                },
-                "osx": null,
-                "linux": null
+                }
             }
         }
     ]
 }
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,7 +62,7 @@ requirements:
    - pylint-venv >=3.0.2
    - pyls-spyder >=0.4.0
    - python-lsp-black >=2.0.0,<3.0.0
-   - python-lsp-ruff>=2.3.0,<3.0.0
+   - python-lsp-ruff >=2.3.0,<3.0.0
    - python-lsp-server >=1.14.0,<1.15.0
    - pyuca >=1.2
    - pyxdg >=0.26                      # [linux]


### PR DESCRIPTION
fix schema validation on win
topic: https://anaconda.slack.com/archives/C03J3NQPS0Z/p1771514120196429?thread_ts=1771504993.723649&cid=C03J3NQPS0Z

Background: There was a bug in menuinst when that file was created. That bug created shortcuts for platforms that didn’t appear in the menu file. To prevent these shortcuts from being created, the platforms had to be set to null. This was technically not compliant with the schema. This was fixed in [conda/menuinst#350](https://github.com/conda/menuinst/pull/350).

Now that conda-build raises an exception when the schema validation fails, this workaround becomes an error. This does not affect package installations, so our users will be fine.
